### PR TITLE
Restore old ticket status column, change "Open-Pending" status color and restore old 'Closed' status

### DIFF
--- a/src/description.ts
+++ b/src/description.ts
@@ -1,3 +1,5 @@
+const CUSTOM_FIELD_CHILD_OF = 360013377052;
+
 /**
  * Add a sort button.
  */
@@ -182,23 +184,9 @@ function isDummyComment(
   ticketInfo: TicketMetadata,
   comment: Element
 ) : boolean {
+  var childOf = getCustomFieldValue(ticketInfo, CUSTOM_FIELD_CHILD_OF);
 
-  var isChildTicket = false;
-  var customFields = ticketInfo.ticket.custom_fields;
-
-  for (var i = 0; i < customFields.length; i++) {
-    var customField = customFields[i];
-
-    if (customField.id != 360013377052) {
-      continue;
-    }
-
-    if (customField.value && (customField.value.indexOf('child_of:') != -1)) {
-      isChildTicket = true;
-    }
-  }
-
-  if (!isChildTicket) {
+  if (childOf == null || childOf.indexOf('child_of:') == -1) {
     return false;
   }
 
@@ -216,6 +204,14 @@ function isDummyComment(
   }
 
   return false;
+}
+
+/**
+ * Returns the custom field value
+ */
+function getCustomFieldValue(ticketInfo: TicketMetadata, fieldId: number) {
+  var matchingFields = ticketInfo.ticket.custom_fields.filter(function (it) { return it.id == fieldId; });
+  return matchingFields.length == 0 ? null : matchingFields[0].value;
 }
 
 /**

--- a/src/knowledge.ts
+++ b/src/knowledge.ts
@@ -1,10 +1,7 @@
 function addArticleCodeButton(
-  toolbarContainer : HTMLDivElement,
+  toolbar : HTMLElement,
   tinymce : TinyMCE
 ) : void {
-  // Gets the buttons toolbar
-  var toolbar = <HTMLDivElement> toolbarContainer.querySelector('.ssc-view-3d4f1d68.ssc-group-f60b19bf');
-
   // Creates the code format container button
   var codeFormatButton = document.createElement('div');
   codeFormatButton.classList.add('ssc-view-3d4f1d68', 'src-components-EditorToolbar-ToolbarButton---button---2IfvR');
@@ -111,18 +108,18 @@ function addArticleSubmissionListeners(tinymce : TinyMCE) : void {
 }
 
 function addArticleFormattingButtons(tinymce : TinyMCE) : void {
-  var toolbarContainers = <Array<HTMLDivElement>> Array.from(document.querySelectorAll('div[class*="ssc-container-84a82f2f src-components-EditorToolbar-index---bar---"]'));
+  var preButtons = <Array<HTMLDivElement>> Array.from(document.querySelectorAll('div[data-test-id="toolbarPreButton"]'));
 
-  for (var i = 0; i < toolbarContainers.length; i++) {
-    var toolbarContainer = toolbarContainers[i];
+  for (var i = 0; i < preButtons.length; i++) {
+    var toolbar = preButtons[i].parentElement;
 
-    if (toolbarContainer.classList.contains('lesa-ui-stackedit')) {
+    if (toolbar == null || toolbar.classList.contains('lesa-ui-stackedit')) {
       continue;
     }
 
-    toolbarContainer.classList.add('lesa-ui-stackedit');
+    toolbar.classList.add('lesa-ui-stackedit');
 
-    addArticleCodeButton(toolbarContainer, tinymce);
+    addArticleCodeButton(toolbar, tinymce);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -316,16 +316,24 @@ function oldTicketStatusColumn() {
   }
 }
 function updateBadge(badge: HTMLElement) {
-  /* Change badge colors for Open-Pending */
-  if (badge.textContent === 'Open-Pending') {
-    badge.style.setProperty("background-color", "#c782fc", "important");
+  /* Change badge colors for Open-Pending to purple */
+  if ((badge.textContent === 'Open-Pending' || badge.textContent === 'OP')) {
+    if (!badge.getAttribute('updated-open-color')) {
+      badge.style.setProperty("background-color", "#c782fc", "important");
+      badge.setAttribute('updated-open-color', "true");
+    }
+  }
+ /* Restore badge color if changing from Open-Pending to any other status */
+  else if (badge.getAttribute('updated-open-color')) {
+    badge.style.removeProperty("background-color");
+    badge.removeAttribute('updated-open-color')
   }
   /* Closed status was lost now is shown as Resolved, we can get it again from badge attributes */
-  else if ((badge.getAttribute('data-test-id') === 'status-badge-closed') || badge.classList.contains('closed')) {
+  else if (!badge.getAttribute('updated-closed-color') && ((badge.getAttribute('data-test-id') === 'status-badge-closed') || badge.classList.contains('closed'))) {
     badge.style.setProperty("background-color", "#dcdee0", "important");
     badge.style.setProperty("color", "#04363d", "important");
-
-    badge.textContent = 'Closed'
+    badge.textContent = 'Closed';
+    badge.setAttribute('updated-closed-color', "true");
   }
 }
 function isBadgeInPopup(badge: HTMLElement) {

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.3
+// @version        16.4
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.2
+// @version        16.3
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

After https://liferay.slack.com/archives/CL8DNJYB0/p1675440794494529 changes, a new "Open-Pending" status was added to zendesk. This causes three problems to the ticket view list:
1. This status shares the same color than the "Open" status, so it is difficult to differentiate them at a glance. 
2. The 'Closed' status is not displayed anymore, now it is displayed as 'Resolved'
3. Instead of displaying only one letter, the full name of the ticket status is displayed, wasting some screen space for other view list columns.

My pull request fixes these problems, see commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/c38928a6bda0f275ce74240bf347e476f83b8aa7

1. The "Open-Resolved" status color is changed to purple.
2. The "Closed" status is added again with its original color
3. In the ticket view list, the status names are shortened to the first letter, with two exceptions: Open-Pending => OP and On-Hold => H
4. An unused empty column is removed and some padding space is removed.

I have added an additional commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/13170f3192b317fcaac2cca49961d5c82be100eb where I am copying some changes from [liferay-faster-deploy repository](https://github.com/holatuwol/liferay-faster-deploy/commit/387a0b191b8e655bc933aaa804542ab82070d00b) that wasn't applied to this one.