### PR TITLE
Update link to the customer information to the new Customer Portal 2.0

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -32,22 +32,6 @@ function generateFormField(
 
   propertyBox.appendChild(formField);
 }
-
-/**
- * Generate a URL to Customer Portal's account details view.
- */
-
-function getCustomerPortalAccountsHREF(
-  params: {[s: string] : string}
-) : string {
-
-  var portletId = 'com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet';
-  var ns = '_' + portletId + '_';
-
-  var queryString = Object.keys(params).map(function(key) { return (key.indexOf('p_p_') == 0 ? key : (ns + key)) + '=' + encodeURIComponent(params[key]) }).join('&');
-  return 'https://customer.liferay.com/project-details?p_p_id=' + portletId + '&' + queryString;
-}
-
 /**
  * Add the Organization field to the sidebar, which will contain a link to Help Center
  * for the account details and the customer's SLA level.
@@ -90,15 +74,8 @@ function addOrganizationField(
     var organizationFields = organizationInfo.organization_fields;
     serviceLevel.push(organizationFields.sla.toUpperCase());
 
-    helpCenterLinkHREF = getCustomerPortalAccountsHREF({
-      mvcRenderCommandName: '/view_account_entry',
-      accountEntryId: organizationInfo.external_id
-    });
-  }
-  else if (accountCode) {
-    helpCenterLinkHREF = getCustomerPortalAccountsHREF({
-      keywords: accountCode
-    });
+    helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
+       organizationInfo.organization_fields.account_key;
   }
 
   var helpCenterItems = [];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,7 @@ type OrganizationMetadata = {
   external_id: string;
   organization_fields: {
     account_code: string;
+    account_key: string;
     country: string;
     sla: string;
     support_region: string;

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.6
+// @version        16.7
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

Some weeks ago, the new Customer Portal 2.0 was released, see announcement: https://liferay.slack.com/archives/CJ1ERLHUZ/p1680102554868519

Now the customer information is located in the URL https://support.liferay.com/project/#/KOR-nnnnnnnn

The old location in https://customer.liferay.com/project-details it doesn't display any customer information.

In this PR I am switching to the new URL, that just uses the `account_key` id