### PR TITLE
When changing to another ticket (another tab), Patcher Portal version is not updated

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -120,31 +120,10 @@ function getPatcherPortalAccountsHREF(
 }
 
 /**
- * Retrieve the Liferay version from the sidebar.
+ * Retrieve the Liferay version from the tags.
  */
 
 function getProductVersion(tags: string[]) : string {
-  var propertyBoxes = getPropertyBoxes();
-
-  for (var i = 0; i < propertyBoxes.length; i++) {
-    var propertyBox = propertyBoxes[i];
-
-    var parentElement = <HTMLElement> propertyBox.parentElement;
-    var productVersionField = parentElement.querySelector('.custom_field_360006076471 div[data-garden-id="dropdowns.select"]');
-
-    if (productVersionField) {
-      var version = (productVersionField.textContent || '').trim();
-
-      if (version.indexOf('7.') == 0) {
-        return version;
-      }
-
-      if (version.indexOf('6.') == 0) {
-        return '6.x';
-      }
-    }
-  }
-
   for (var i = 0; i < tags.length; i++) {
     var tag = tags[i];
 
@@ -158,6 +137,16 @@ function getProductVersion(tags: string[]) : string {
 
     if (x != -1) {
       return '7.' + tag.charAt(x + 3);
+    }
+
+    x = tag.indexOf('6_');
+    if (x == 0) {
+      return '6.x';
+    }
+
+    x = tag.indexOf('_6_');
+    if (x != -1) {
+      return '6.x';
     }
   }
 

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.8
+// @version        16.9
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

The getProductVersion method is returning wrong version information when you switch between opened tickets, it seems the information returned by `getPropertyBoxes()` returns data from other opened tickets, so the Patcher Portal link version points to the one from the previous ticket.

To avoid this error, it is better to rely on tags information.

This was already reported by @joseluisbango here https://github.com/holatuwol/liferay-zendesk-userscript/issues/8

> Scenario: You have 2 tickets. These tickets are open in the same browser tab:
> 
>     * Ticket **A**: version 7.3
> 
>     * Ticket **B**: version 7.2
> 
> 
> If you change from **B** to **A**, version-specific text and link of Patcher Portal Builds are not updated. See the following image.
> 
> As a workaround, I have tried retrieving the version from tags first in [getProductVersion()](https://github.com/holatuwol/liferay-zendesk-userscript/blob/master/src/sidebar.ts#L149-L188) and it seems to work fine.
> 
> ![image](https://user-images.githubusercontent.com/82962073/209832289-91e9c10f-b370-4771-878f-86cae623f9d8.png)


