### PR TITLE
Fix the logic that removes the space before the status column

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -339,25 +339,29 @@ function removeTicketStatusColumn() : void {
       continue;
     }
 
-    var statusHeaderCell = (<HTMLTableSectionElement> table.tHead).rows[0].cells[statusIndex];
+    var headerCells = <Array<HTMLTableCellElement>> Array.from((<HTMLTableSectionElement> table.tHead).rows[0].cells);
+    var statusHeaderCell = headerCells[statusIndex];
 
     if (statusHeaderCell.getAttribute('processed') == 'true') {
       continue
     }
 
     /* remove "Ticket status" text from headers */
-    statusHeaderCell.setAttribute('processed', 'true');
     statusHeaderCell.textContent = ' ';
 
+    for (var headerCell of headerCells) {
+      headerCell.setAttribute('processed', 'true');
+    }
+
     /* remove the padding of the column 2 before the status column */
-    var cells = <Array<HTMLTableCellElement>> Array.from(table.querySelectorAll('tr:nth-child(' + (statusIndex - 1) + ')'));
+    var cells = <Array<HTMLTableCellElement>> Array.from(table.querySelectorAll('td:nth-child(' + (statusIndex - 1) + ')'));
     for (var cell of cells) {
       cell.style.paddingLeft = '0px';
       cell.style.paddingRight = '2px';
     }
 
     /* remove the column 1 before the status column */
-    cells = <Array<HTMLTableCellElement>> Array.from(table.querySelectorAll('tr:nth-child(' + (statusIndex) + ')'));
+    cells = <Array<HTMLTableCellElement>> Array.from(table.querySelectorAll('td:nth-child(' + (statusIndex) + ')'));
     for (var cell of cells) {
       cell.remove();
     }

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        17.0
+// @version        17.1
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

I have detected that the logic of your last commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/6bab6fe3ea5729b2cd26be232936ea4be5ae39d4 that removes  space before the status column is not correctly working.

The space is not removed because we should use `td` instead of `tr` when getting the cells from the table:
`var cells = <Array<HTMLTableCellElement>> Array.from(table.querySelectorAll('td:nth-child(' + (statusIndex - 1) + ')'));
`

After changing this, we have also to add the 'processed' flag to all the table headers because statusIndex is recalculated after the empty cells are removed, so all the columns at the left side of the status column are removed.

Let me know if you have any question