### PR TITLE
Avoid labeling some created LPP tickets from Brazil office with both Brazil and Spain offices values

### DIFF
--- a/src/jira.ts
+++ b/src/jira.ts
@@ -234,7 +234,7 @@ function getSupportOffices(
     supportOffices.push('Japan');
   }
 
-  if ((assigneeGroup.indexOf('Spain Pod') == 0) || (assigneeGroup.indexOf(' - ES') != -1)) {
+  if ((assigneeGroup.indexOf('Spain Pod') == 0) || ((assigneeGroup.indexOf(' - ES') != -1) && (assigneeGroup.indexOf('- BR') == -1) )) {
     supportOffices.push('Spain');
   }
 

--- a/src/priority.ts
+++ b/src/priority.ts
@@ -196,7 +196,7 @@ function getSupportRegions(
     supportRegions.push('Japan');
   }
 
-  if ((assigneeText.indexOf('Spain Pod') == 0) || (isSupportRegion(assigneeText, 'ES'))) {
+  if ((assigneeText.indexOf('Spain Pod') == 0) || (isSupportRegion(assigneeText, 'ES') && !isSupportRegion(assigneeText, 'BR'))) {
     supportRegions.push('Spain');
   }
 

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        17.9
+// @version        18.0
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Some LPP tickets from Brazil office were wrongly labeled as belonging to Brazil and Spain offices.
Some examples of affected LPPs are LPP-42255, LPP-50011, LPP-50642, LPP-50664 you can see in the 'history' tab that I removed the 'Spain' value from the "Support Office" field as they were tickets from Brazil office.

The root cause if this issue is Brazil office have a group called 'CSE - BR - ES' for the Spanish speaking CSEs, as this group has both 'BR' and 'ES' fragments, the code label them as belonging to both offices.

To avoid this problem, I have added an extra condition to exclude from Spain the assignees with both 'ES' and 'BR' string fragments.

This is a bit urgent as this is breaking some of our JIRA filters and statistics.

Thank you

cc @jcampoy