### PR TITLE
Add an 'edit' link to provisioning.liferay.com to be able to edit the notes easily

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -134,6 +134,12 @@ function addOrganizationField(
 
   var notesItems = [];
 
+  if (organizationInfo) {
+    var provisioningSupportInstructionsLink = createAnchorTag(
+    "edit", "https://provisioning.liferay.com/group/guest/~/control_panel/manage?p_p_id=com_liferay_osb_provisioning_web_portlet_AccountsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_mvcRenderCommandName=%2Faccounts%2Fview_account&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_tabs1=support&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_accountKey=" + organizationInfo.organization_fields.account_key);
+    notesItems.push(provisioningSupportInstructionsLink);
+  }
+
   if (organizationInfo && organizationInfo.notes) {
     var notesContainer = document.createElement('div');
     notesContainer.textContent = organizationInfo.notes;

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        19.1
+// @version        19.2
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

About the 'notes' section added in 3b2a8aa7d600fa3e560f2d71ed59ce7f89366715 if a CSE has to update the notes of a customer, they have to manually access to https://provisioning.liferay.com/ and search the account in order to update it.

This is procedure explained here [Support Instructions SOP - Update Procedure](https://liferay.atlassian.net/wiki/spaces/SUPPORT/pages/2256896269/Support+Instructions+SOP#Update-Procedure) and [in the #d-sub-services slack channel](https://liferay.slack.com/archives/CL8DNJYB0/p1701753086508839)

In order to make easier updating this information, in this PR I am adding a new "edit" link that points to the provisioning.liferay.com page with the customer information.

This will allow our HelpCenter users to open the customer account page in provisioning.liferay.com directly, without having to manually search it.

Can we add this to you zendesk script?

Thank you,
Regards,
Jorge