### PR TITLE
Reduce the 'Heat Score' and 'Product' column width to save space

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,46 @@ function fixOldTicketStatusColumnStyle() : void {
 
   if (viewPage) {
     removeTicketStatusColumn();
+    adjustColumnTextWidth();
     unsafeWindow.dispatchEvent(new Event('resize'));
+  }
+}
+
+function adjustColumnTextWidth(): void {
+  var tables = Array.from(document.querySelectorAll<HTMLTableElement>('table[data-onboarding-id="table_main"], table[data-test-id="table_header"]'));
+
+  for (var table of tables) {
+    var headers = Array.from((<HTMLTableSectionElement>table.tHead).rows[0].cells);
+    for (var header of headers) {
+      if (header.getAttribute('heatscore_processed') === 'true') {
+        continue;
+      }
+      var textHeader = getTextHeader(header);
+      if (textHeader && (textHeader.nodeValue === 'Heat Score')) {
+        var button = header.querySelector('button');
+        if (button) {button.title = 'Heat Score';}
+
+        textHeader.nodeValue = 'Heat';
+      }
+      header.setAttribute('heatscore_processed', 'true');
+    }
+  }
+
+  function getTextHeader(header: HTMLTableCellElement): ChildNode | null {
+    var button = header.querySelector('button');
+    if (!button) {
+      return null;
+    }
+
+    if (!button.firstChild) {
+      return null;
+    }
+
+    if (button.firstChild.nodeType === Node.TEXT_NODE) {
+      return button.firstChild;
+    }
+
+    return null;
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -321,6 +321,42 @@ function adjustColumnTextWidth(): void {
       }
       header.setAttribute('heatscore_processed', 'true');
     }
+
+    var product_column;
+    var i = 0;
+    for (var header of headers) {
+      var textHeader = getTextHeader(header);
+      if (textHeader && (textHeader.nodeValue === 'Product')) {
+        product_column = i;
+        break;
+      }
+      i++;
+    }
+    if (!product_column) {
+      continue;
+    }
+
+    var rows = Array.from((<HTMLCollectionOf<HTMLTableSectionElement>>table.tBodies)[0].rows);
+    for (var row of rows) {
+      var cell = row.cells[product_column];
+      if (!cell || !cell.textContent || cell.getAttribute('product_processed')) {
+        continue;
+      }
+      cell.title = cell.textContent;
+      if (cell.textContent === 'Liferay DXP::Quarterly Release') {
+        cell.textContent = 'DXP::Quarterly';
+      }
+      else if (cell.textContent === 'LXC - Self-Managed') {
+        cell.textContent = 'LXC - SM';
+      }
+      else if (cell.textContent === 'Provisioning Request') {
+        cell.textContent = 'Provisioning';
+      }
+      else if (cell.textContent.startsWith('Liferay ')) {
+        cell.textContent = cell.textContent.replace('Liferay ', '');
+      }
+      cell.setAttribute('product_processed', 'true');
+    }
   }
 
   function getTextHeader(header: HTMLTableCellElement): ChildNode | null {

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        19.2
+// @version        19.3
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

In this PR I am changing the 'Heat Score' and 'Product' column width to save space:

- Changing the header from 'Heat Score' to 'Heat', because the data is narrower than the header
- Changing the data from the product column, removing the "Liferay" prefix to every row.

**After this PR changes:**
![image](https://github.com/holatuwol/liferay-zendesk-userscript/assets/6472845/f9d3c136-7806-4054-8814-f8b2d1f86ac4)
**Before this PR changes:**
![image](https://github.com/holatuwol/liferay-zendesk-userscript/assets/6472845/787e2ba5-a0a3-4dd2-9f9e-7cb55f8f2378)

Let me know if you have any question