### PR TITLE
Add sub organization information to the ticket if the organization has one selected (+ some changes from liferay-faster-deploy repo)

### DIFF
--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -60,7 +60,7 @@ function extractAttachmentLinkMetadata(
   attachmentLink: HTMLAnchorElement
 ) : AttachmentLinkMetadata {
 
-  var comment = <HTMLDivElement> attachmentLink.closest(isAgentWorkspace ? 'article' : 'div[data-comment-id]');
+  var comment = <HTMLDivElement> attachmentLink.closest('article');
 
   // Since we're using the query string in order to determine the name (since the actual text
   // in the link has a truncated name), we need to decode the query string.
@@ -69,7 +69,7 @@ function extractAttachmentLinkMetadata(
   encodedFileName = encodedFileName.replace(/\+/g, '%20');
   var attachmentFileName = decodeURIComponent(encodedFileName);
 
-  var authorElement = <HTMLElement> comment.querySelector(isAgentWorkspace ? 'span[data-test-id="omni-log-item-sender"]' : 'div.actor .name');
+  var authorElement = <HTMLElement> comment.querySelector('span[data-test-id="omni-log-item-sender"]');
 
   var timeElement = <HTMLTimeElement> comment.querySelector('time');
 
@@ -94,9 +94,9 @@ function extractExternalLinkMetadata(
   externalLink: HTMLAnchorElement
 ) : AttachmentLinkMetadata {
 
-  var comment = <HTMLDivElement> externalLink.closest(isAgentWorkspace ? 'article' : 'div[data-comment-id]');
+  var comment = <HTMLDivElement> externalLink.closest('article');
 
-  var authorElement = <HTMLElement> comment.querySelector(isAgentWorkspace ? 'span[data-test-id="omni-log-item-sender"]' : 'div.actor .name');
+  var authorElement = <HTMLElement> comment.querySelector('span[data-test-id="omni-log-item-sender"]');
 
   var timeElement = <HTMLTimeElement> comment.querySelector('time');
 
@@ -257,15 +257,6 @@ function createAttachmentZip(
 }
 
 /**
- * Function to check if this is a large attachment, since those cannot be automatically
- * included in attachment .zip files due to CORS policies.
- */
-
-function isLiferayLargeAttachment(anchor: HTMLAnchorElement) : boolean {
-  return anchor.href.indexOf('ticketAttachmentId') != -1;
-}
-
-/**
  * Create a container to hold all of the attachments in the ticket, and a convenience
  * link which allows the user to download all of the selected attachments at once.
  */
@@ -280,8 +271,7 @@ function createAttachmentsContainer(
 
   var attachmentThumbnails = <Array<HTMLAnchorElement>> Array.from(conversation.querySelectorAll('a[data-test-id="attachment-thumbnail"]'));
 
-  var externalLinks = <Array<HTMLAnchorElement>> Array.from(conversation.querySelectorAll((isAgentWorkspace ? '' : '.is-public ') + '.zd-comment > a:not(.attachment)'));
-  externalLinks = externalLinks.filter(isLiferayLargeAttachment);
+  var externalLinks = <Array<HTMLAnchorElement>> Array.from(conversation.querySelectorAll('.zd-comment > a:not(.attachment)'));
 
   if (attachmentLinks.length + attachmentThumbnails.length + externalLinks.length == 0) {
     return null;
@@ -289,14 +279,6 @@ function createAttachmentsContainer(
 
   var attachmentsContainer = document.createElement('div');
   attachmentsContainer.classList.add('lesa-ui-attachments');
-
-  if (!isAgentWorkspace) {
-    var attachmentsLabel = document.createElement('div');
-    attachmentsLabel.classList.add('lesa-ui-attachments-label');
-    attachmentsLabel.innerHTML = 'Attachments:';
-
-    attachmentsContainer.appendChild(attachmentsLabel);
-  }
 
   // Accumulate the attachments, and then sort them by date
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,3 @@
-var isAgentWorkspace = false;
 
 /**
  * Waits until elements appear and then click on them.

--- a/src/description.ts
+++ b/src/description.ts
@@ -273,14 +273,7 @@ function addTicketDescription(
   conversation: HTMLDivElement
 ) : void {
 
-  var header = <HTMLElement | null> null;
-
-  if (isAgentWorkspace) {
-    header = <HTMLElement> conversation.childNodes[0];
-  }
-  else {
-    header = conversation.querySelector('.pane_header');
-  }
+  var header = <HTMLElement> conversation.childNodes[0];
 
   if (!header) {
     return;
@@ -288,31 +281,10 @@ function addTicketDescription(
 
   // Check to see if we have any descriptions that we need to remove.
 
-  if (isAgentWorkspace) {
-    var oldLinks = conversation.querySelectorAll('.lesa-ui-modal-header-link');
+  var oldLinks = conversation.querySelectorAll('.lesa-ui-modal-header-link');
 
-    if (oldLinks.length > 0) {
-      return;
-    }
-  }
-  else {
-    var oldDescriptions = conversation.querySelectorAll('.lesa-ui-description');
-
-    var hasNewDescription = false;
-
-    for (var i = 0; i < oldDescriptions.length; i++) {
-      if (oldDescriptions[i].getAttribute('data-ticket-id') == ticketId) {
-        hasNewDescription = true;
-      }
-      else {
-        revokeObjectURLs();
-        header.removeChild(oldDescriptions[i]);
-      }
-    }
-
-    if (hasNewDescription) {
-      return;
-    }
+  if (oldLinks.length > 0) {
+    return;
   }
 
   // Add a marker indicating the LESA priority based on critical workflow rules
@@ -323,38 +295,10 @@ function addTicketDescription(
 
   // Generate something to hold all of our attachments.
 
-  if (isAgentWorkspace) {
-    addHeaderLinkModal('description-modal', 'Description', header, conversation, createDescriptionContainer.bind(null, ticketId, ticketInfo, conversation));
-    addHeaderLinkModal('description-modal', 'Fast Track', header, conversation, createKnowledgeCaptureContainer.bind(null, ticketId, ticketInfo, conversation));
-    addHeaderLinkModal('attachments-modal', 'Attachments', header, conversation, createAttachmentsContainer.bind(null, ticketId, ticketInfo, conversation));
-    addSortButton(conversation, header);
-  }
-  else {
-    var descriptionAncestor1 = document.createElement('div');
-    descriptionAncestor1.classList.add('lesa-ui-description');
-    descriptionAncestor1.classList.add('rich_text');
-    descriptionAncestor1.setAttribute('data-ticket-id', ticketId);
-
-    var descriptionContainer = createDescriptionContainer(ticketId, ticketInfo, conversation);
-
-    if (descriptionContainer) {
-      descriptionAncestor1.appendChild(descriptionContainer);
-    }
-
-    var knowledgeCaptureContainer = createKnowledgeCaptureContainer(ticketId, ticketInfo, conversation);
-
-    if (knowledgeCaptureContainer) {
-      descriptionAncestor1.appendChild(knowledgeCaptureContainer);
-    }
-
-    var attachmentsContainer = createAttachmentsContainer(ticketId, ticketInfo, conversation);
-
-    if (attachmentsContainer) {
-      descriptionAncestor1.appendChild(attachmentsContainer);
-    }
-
-    header.appendChild(descriptionAncestor1);
-  }
+  addHeaderLinkModal('description-modal', 'Description', header, conversation, createDescriptionContainer.bind(null, ticketId, ticketInfo, conversation));
+  addHeaderLinkModal('description-modal', 'Fast Track', header, conversation, createKnowledgeCaptureContainer.bind(null, ticketId, ticketInfo, conversation));
+  addHeaderLinkModal('attachments-modal', 'Attachments', header, conversation, createAttachmentsContainer.bind(null, ticketId, ticketInfo, conversation));
+  addSortButton(conversation, header);
 }
 
 function createDescriptionContainer(
@@ -363,7 +307,7 @@ function createDescriptionContainer(
   conversation: HTMLDivElement
 ) : HTMLDivElement | null {
 
-  var comments = conversation.querySelectorAll(isAgentWorkspace ? 'article' : '.event .zd-comment');
+  var comments = conversation.querySelectorAll('article');
 
   if (comments.length == 0) {
     return null;
@@ -372,10 +316,6 @@ function createDescriptionContainer(
   var descriptionContainer = document.createElement('div');
 
   descriptionContainer.classList.add('is-public');
-
-  if (!isAgentWorkspace) {
-    descriptionContainer.classList.add('event');
-  }
 
   var tags = (ticketInfo && ticketInfo.ticket && ticketInfo.ticket.tags) || [];
   var tagSet = new Set(tags);
@@ -398,10 +338,10 @@ function createDescriptionContainer(
     descriptionContainer.appendChild(flsContainer);
   }
 
-  var firstComment = comments[isAgentWorkspace ? 0 : comments.length - 1];
+  var firstComment = comments[0];
 
   if (isDummyComment(ticketInfo, firstComment)) {
-    firstComment = comments[isAgentWorkspace ? 1 : comments.length - 2];
+    firstComment = comments[1];
   }
 
   var description = document.createElement('div');

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,24 +19,6 @@ function fixAttachmentLinksHelper(
 }
 
 /**
- * Shows the public conversation tab so that you can get help.liferay.com links to
- * share with customers.
- */
-
-function enablePublicConversation(
-  ticketId: string,
-  ticketInfo: TicketMetadata,
-  conversation: HTMLDivElement
-) : void {
-
-  var fullTab = <HTMLElement> conversation.querySelector('.event-nav.conversation .fullConversation');
-  var publicTab = conversation.querySelector('.event-nav.conversation .publicConversation');
-
-  if (publicTab && parseInt(publicTab.getAttribute('data-count') || '0') == 0) {
-    publicTab.setAttribute('data-count', fullTab.getAttribute('data-count') || '0');
-  }
-}
-/**
  * Apply updates to the page based on the retrieved ticket information. Since the
  * ticket corresponds to a "conversation", find that conversation.
  */
@@ -63,20 +45,9 @@ function checkTicketConversation(
   }
 
   var hasAgentWorkspaceComments = conversation.querySelectorAll('article').length > 0;
-  var hasLegacyWorkspaceComments = conversation.querySelectorAll('.event .zd-comment').length > 0;
 
-  if (!hasAgentWorkspaceComments && !hasLegacyWorkspaceComments) {
+  if (!hasAgentWorkspaceComments) {
     return;
-  }
-
-  isAgentWorkspace = hasAgentWorkspaceComments;
-
-  if (!isAgentWorkspace && document.querySelectorAll('.editor').length == 0) {
-    return;
-  }
-
-  if (!isAgentWorkspace) {
-    enablePublicConversation(ticketId, ticketInfo, conversation);
   }
 
   addReplyFormattingButtons(ticketId, ticketInfo, conversation);

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -75,7 +75,7 @@ function highlightComment(
     return;
   }
 
-  var event = <HTMLElement> comment.closest(isAgentWorkspace ? 'article' : '.event');
+  var event = <HTMLElement> comment.closest('article');
 
   if (!force && event.classList.contains('lesa-ui-event-highlighted')) {
     return;
@@ -126,8 +126,7 @@ function addPermaLinks(
   conversation: HTMLDivElement
 ) : void {
 
-  var comments = conversation.querySelectorAll(isAgentWorkspace ? 'article' : 'div[data-comment-id]');
-  var isPublicTab = !isAgentWorkspace && document.querySelector('.publicConversation.is-selected');
+  var comments = conversation.querySelectorAll('article');
 
   for (var i = 0; i < comments.length; i++) {
     var timeElement = comments[i].querySelector('time');
@@ -138,28 +137,16 @@ function addPermaLinks(
 
     var commentHeader = null;
 
-    if (isAgentWorkspace) {
-      var actionsElement = <HTMLElement>comments[i].querySelector('.omnilog-header-actions');
-      commentHeader = actionsElement.parentElement
-    }
-    else {
-      commentHeader = comments[i].querySelector('.content .header');
-    }
+    var actionsElement = <HTMLElement>comments[i].querySelector('.omnilog-header-actions');
+    commentHeader = actionsElement.parentElement
 
     if (!commentHeader) {
       continue;
     }
 
-    if (isAgentWorkspace) {
-      var parentElement = <HTMLElement>commentHeader.parentElement;
-      if (parentElement.querySelector('.lesa-ui-permalink')) {
-        continue;
-      }
-    }
-    else {
-      if (commentHeader.querySelector('.lesa-ui-permalink')) {
-        continue;
-      }
+    var parentElement = <HTMLElement>commentHeader.parentElement;
+    if (parentElement.querySelector('.lesa-ui-permalink')) {
+      continue;
     }
 
     var commentId = timeElement.getAttribute('datetime');
@@ -169,20 +156,10 @@ function addPermaLinks(
 
     var permalinkHREF = 'https://' + document.location.host + document.location.pathname + '?comment=' + commentId;
 
-    if (isPublicTab) {
-      var pageId = Math.ceil((comments.length - i) / 30);
-      permalinkHREF = 'https://help.liferay.com/hc/requests/' + ticketId + '?page=' + pageId + '#request_comment_' + commentId;
-    }
-
     var permalink = createPermaLinkInputField(permalinkHREF);
     permalinkContainer.appendChild(permalink);
 
-    if (isAgentWorkspace) {
-      commentHeader.after(permalinkContainer);
-    }
-    else {
-      commentHeader.appendChild(permalinkContainer);
-    }
+    commentHeader.after(permalinkContainer);
   }
 }
 

--- a/src/priority.ts
+++ b/src/priority.ts
@@ -364,20 +364,15 @@ function addPriorityMarker(
     priorityElement.appendChild(emojiContainer);
   }
 
-  if (isAgentWorkspace) {
-    var viaLabel = <HTMLDivElement> conversation.querySelector('div[data-test-id="omni-header-via-label"]');
+  var viaLabel = <HTMLDivElement> conversation.querySelector('div[data-test-id="omni-header-via-label"]');
 
-    var divider = document.createElement('div');
-    divider.classList.add('Divider-sc-2k6bz0-9');
+  var divider = document.createElement('div');
+  divider.classList.add('Divider-sc-2k6bz0-9');
 
-    if (priorityElement.childNodes.length > 0) {
-      divider.classList.add('fNgWaW');
-    }
-
-    viaLabel.before(divider);
-    divider.before(priorityElement);
+  if (priorityElement.childNodes.length > 0) {
+    divider.classList.add('fNgWaW');
   }
-  else {
-    header.insertBefore(priorityElement, header.querySelector('.round-avatar'));
-  }
+
+  viaLabel.before(divider);
+  divider.before(priorityElement);
 }

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -165,7 +165,7 @@ function addPlaybookReminder(
   conversation: HTMLDivElement
 ) : void {
 
-  var editor = conversation.querySelector(isAgentWorkspace ? 'div[data-test-id="omnicomposer-rich-text-ckeditor"]' : '.editor');
+  var editor = conversation.querySelector('div[data-test-id="omnicomposer-rich-text-ckeditor"]');
 
   if (!editor) {
     return;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -315,6 +315,13 @@ function addPatcherPortalField(
 
       patcherPortalItems.push(createAnchorTag(version + ' Builds', versionBuildsLinkHREF));
     }
+    if (version == '7.4') {
+        var versionBuildsLinkHREF = getPatcherPortalAccountsHREF('/view', {
+            'patcherBuildAccountEntryCode': accountCode,
+            'patcherProductVersionId': getProductVersionId('Quarterly Release')
+        });
+        patcherPortalItems.push(createAnchorTag('Quarterly Release Builds', versionBuildsLinkHREF));
+    }
   }
   else if (ticketId) {
     patcherPortalItems.push(document.createTextNode('N/A'));

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -112,6 +112,7 @@ function addOrganizationField(
 
   var helpCenterLinkHREF = null;
   var serviceLevel = <string[]> [];
+  var subOrganizationTag = null;
 
   if (tagSet.has('t1')) {
     serviceLevel.push('Account Tier 1');
@@ -161,6 +162,8 @@ function addOrganizationField(
 
     helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
        organizationInfo.organization_fields.account_key;
+
+    subOrganizationTag = organizationFields.sub_organization;
   }
 
   var helpCenterItems = [];
@@ -186,6 +189,14 @@ function addOrganizationField(
   helpCenterItems.push(createPermaLinkInputField(permalinkHREF))
 
   generateFormField(propertyBox, 'lesa-ui-helpcenter', 'Help Center', helpCenterItems);
+
+  if (subOrganizationTag) {
+    var subOrganizationContainer = document.createElement('div');
+    var subOrganizationName = subOrganizationTag.split("_").map(function (word) { return word.charAt(0).toUpperCase() + word.slice(1); }).join(" "); /* replace underscores with spaces and capitalize: spain_pod_a => Spain Pod A */
+    subOrganizationContainer.appendChild(document.createTextNode(subOrganizationName));
+
+    generateFormField(propertyBox, 'lesa-ui-suborganization', 'Sub Organization', [subOrganizationContainer]);
+  }
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -52,6 +52,7 @@ type OrganizationMetadata = {
     account_key: string;
     country: string;
     sla: string;
+    sub_organization: string;
     support_region: string;
   }
   tags: string[];

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        20.0
+// @version        20.1
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        20.1
+// @version        20.2
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        19.9
+// @version        20.0
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/


### PR DESCRIPTION
Hi @holatuwol 

In Spain support office we have two teams where we distribute our customers.

To distribute the customer (=organizations) we use the "Sub Organization" field that is at Organization level:
![image](https://github.com/holatuwol/liferay-zendesk-userscript/assets/6472845/c14f9cee-23d1-4a8c-910c-d96c171c4297)

But this information is not available in the ticket level, so when one person from one team helps with the tickets of the other team, or when working with the provisioning tickets that are handled by the CAS team, the only way to get the "Sub Organization" is checking this information in the "Organization" level.

**My changes**

With my changes in commit 6cea615cae56af0e19ba2e77b2114b402d4b6211 I am adding this information in the left sidebar of the ticket, see:
![image](https://github.com/holatuwol/liferay-zendesk-userscript/assets/6472845/94564744-8688-4b03-b1d8-a8f207854e0f)

**Additional changes**
In this PR I am also adding two additional commits with some changes from https://github.com/holatuwol/liferay-faster-deploy repository that aren't applied to this https://github.com/holatuwol/liferay-zendesk-userscript, see:

- 84c246e05a953d5aa1e9f0860276d22a08d9964d => 20.0 version, copied from https://github.com/holatuwol/liferay-faster-deploy/commit/993302f80df8665bbe28ff94cef3522f2cbc5ee5
- 4a58b25c8ff3b2da2475ce2150e6777ee91c4675 => 21.0 version, copied from https://github.com/holatuwol/liferay-faster-deploy/commit/0820a0e20de01cb356e979ad09569546f29b8887

cc @jcampoy