### PR TITLE
Take into account the user's locale when formatting the date in Jira pop-up modal window

### DIFF
--- a/src/jira.ts
+++ b/src/jira.ts
@@ -20,13 +20,10 @@ function setReactInputValue(
   // Format dates like React datepickers expect.
 
   if (value instanceof Date) {
-    var mm = value.getMonth() + 1;
-    var mmString = (mm < 10) ? '0' + mm : mm;
-    var dd = value.getDate();
-    var ddString = (dd < 10) ? '0' + dd : dd;
-    var yyyy = value.getFullYear();
+    var options = { year: 'numeric', month: '2-digit', day: '2-digit' };
+    var userLocale = navigator.language;
 
-    value = mmString + '/' + ddString + '/' + yyyy;
+    value = new Intl.DateTimeFormat(userLocale, options).format(value);
   }
 
   // Make sure to call the right setter function so the underlying state is updated.


### PR DESCRIPTION
Hey @holatuwol ,

Currently, there is an issue when formatting the date depending on user's locale.

For example, today is September 5th. The script currently sets 09/05/2024 (`mm/dd/yyyy`), but for `es` locale it means May 9th (`dd/mm/yyyy`).

I've implemented this fix by leveraging [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
It works for me, but you may want a different approach.

Regards