### PR TITLE
Avoid errors when opening tickets from the 'Provisioning' account

### DIFF
--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -202,6 +202,9 @@ function addOrganizationField(
 
     generateFormField(propertyBox, 'lesa-ui-suborganization', 'Sub Organization', [subOrganizationContainer]);
   }
+  else {
+    generateFormField(propertyBox, 'lesa-ui-suborganization', '', []);
+  }
 }
 
 /**

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -158,7 +158,10 @@ function addOrganizationField(
 
   if (organizationInfo) {
     var organizationFields = organizationInfo.organization_fields;
-    serviceLevel.push(organizationFields.sla.toUpperCase());
+    var sla = organizationFields.sla;
+    if (sla) {
+      serviceLevel.push(sla.toUpperCase());
+    }
 
     helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
        organizationInfo.organization_fields.account_key;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -135,7 +135,7 @@ function addOrganizationField(
 
   var notesItems = [];
 
-  if (organizationInfo) {
+  if (organizationInfo && organizationInfo.organization_fields.account_key) {
     var provisioningSupportInstructionsLink = createAnchorTag(
     "edit", "https://provisioning.liferay.com/group/guest/~/control_panel/manage?p_p_id=com_liferay_osb_provisioning_web_portlet_AccountsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_mvcRenderCommandName=%2Faccounts%2Fview_account&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_tabs1=support&_com_liferay_osb_provisioning_web_portlet_AccountsPortlet_accountKey=" + organizationInfo.organization_fields.account_key);
     notesItems.push(provisioningSupportInstructionsLink);
@@ -163,8 +163,10 @@ function addOrganizationField(
       serviceLevel.push(sla.toUpperCase());
     }
 
-    helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
-       organizationInfo.organization_fields.account_key;
+    if (organizationInfo.organization_fields.account_key) {
+      helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
+        organizationInfo.organization_fields.account_key;
+    }
 
     subOrganizationTag = organizationFields.sub_organization;
   }

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        22.1
+// @version        22.2
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new


### PR DESCRIPTION
In zendesk we have a 'Provisioning' account with an special 0000000 account code.

See tickets: https://liferay-support.zendesk.com/agent/organizations/360796490792/tickets

I have detected that when you open a ticket from that account, there are several errors:

- An `Uncaught TypeError: organizationFields.sla is null` error is thrown, because this special account has no SLA, see commit 462b1a4efa46fa1c0462e06e06bd9259dbf56033
- Some of the generated links are wrong, pointing to an URL ending in 'null', see commit 9f5789c0f7f218195d992f66a25881ac5cd2e750
- If you change from a regular ticket to a ticket from that account, some of the data in the sidebar is not refreshed, so wrong data from previous ticket is displayed, see commit 6055c9df582400376145cd4d07b0b662f8451fd1

Let me know if you have any question