### PR TITLE
Add a new script settings section using 'GM_Config'. Allow enabling/disabling Swarming Skills on every row of the tickets list.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -313,7 +313,7 @@ function adjustColumnTextWidth() : boolean {
     var i = 0;
     for (var header of headers) {
       var textHeader = getTextHeader(header);
-      if (textHeader && (textHeader.nodeValue === 'Product')) {
+      if (textHeader && (textHeader.nodeValue === 'Offering')) {
         product_column = i;
         break;
       }
@@ -330,12 +330,8 @@ function adjustColumnTextWidth() : boolean {
         continue;
       }
       cell.title = cell.textContent;
-      if (cell.textContent === 'Liferay DXP::Quarterly Release') {
-        cell.textContent = 'DXP::Quarterly';
-        madeResizeChanges = true;
-      }
-      else if (cell.textContent === 'LXC - Self-Managed') {
-        cell.textContent = 'LXC - SM';
+      if (cell.textContent === 'Liferay Self-Hosted::Quarterly Release') {
+        cell.textContent = 'Self-Hosted::Quarterly';
         madeResizeChanges = true;
       }
       else if (cell.textContent === 'Provisioning Request') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -517,6 +517,12 @@ GM_config.init({
   id: 'zendesk_for_tse_config',
   title: GM_info.script.name + ' Settings',
   fields: {
+      DISPLAY_SWARMING_CATEGORIES_ON_LIST: {
+          label: 'Display Swarming Skills on ticket rows',
+          type: 'checkbox',
+          default: true,
+          title: 'Check if you want to display the Swarming Skils on ticket rows below the ticket title in filter viewsCheck if you want to display the Swarming Skils on ticket rows below the ticket title in filter views. This will make rows larger vertically.'
+      },
       EXECUTION_INTERVAL: {
           label: 'Execution interval (ms)',
           type: 'number',

--- a/src/main.ts
+++ b/src/main.ts
@@ -513,7 +513,29 @@ function updateZendeskUI() : void {
   }
 }
 
-// Since there's an SPA framework in place that I don't fully understand,
-// attempt to do everything once per second.
+GM_config.init({
+  id: 'zendesk_for_tse_config',
+  title: GM_info.script.name + ' Settings',
+  fields: {
+      EXECUTION_INTERVAL: {
+          label: 'Execution interval (ms)',
+          type: 'number',
+          min: 1,
+          default: 1000,
+          title: 'The number of milliseconds to wait between each execution of the script'
+      }
+  },
+  events: {
+      init: onInit
+  }
+})
 
-setInterval(updateZendeskUI, 1000);
+GM_registerMenuCommand('Settings', () => {
+  GM_config.open()
+})
+
+function onInit() {
+  // Since there's an SPA framework in place that I don't fully understand,
+  // attempt to do everything once per second.
+  setInterval(updateZendeskUI, GM_config.get('EXECUTION_INTERVAL'));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -523,6 +523,12 @@ GM_config.init({
           default: true,
           title: 'Check if you want to display the Swarming Skils on ticket rows below the ticket title in filter viewsCheck if you want to display the Swarming Skils on ticket rows below the ticket title in filter views. This will make rows larger vertically.'
       },
+      DISPLAY_SUB_ORGANIZATION_ON_LIST: {
+          label: 'Display suborganization information on tickets rows (Spain office only)',
+          type: 'checkbox',
+          default: false,
+          title: 'Check if you want to display the suborganization information on ticket rows below the ticket title'
+      },
       EXECUTION_INTERVAL: {
           label: 'Execution interval (ms)',
           type: 'number',

--- a/src/style.ts
+++ b/src/style.ts
@@ -323,6 +323,16 @@ td[data-test-id="ticket-table-cells-subject"] .lesa-ui-tags span {
   padding-right: 0.3em;
 }
 
+td[data-test-id="generic-table-cells-id"] span.lesa-ui-tags {
+  background: rgb(233, 235, 237);
+  border-radius: 0.2em;
+  color: rgb(73, 84, 92);
+  font-size: x-small;
+  margin: 0.2em 0.2em;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+}
+
 div[data-cy-test-id="status-badge-state"] {
   width: 4em;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,6 +24,12 @@ interface GM {
 
 declare var GM : GM;
 
+declare var GM_config : GM_config;
+
+declare var GM_info : GM_info;
+
+declare function GM_registerMenuCommand(name: string, callback: function) : void;
+
 type JiraTicket = {
   subject: string
   createdAt: string

--- a/src/view_columns.ts
+++ b/src/view_columns.ts
@@ -5,6 +5,10 @@ function populateTicketTableExtraColumns(
   tickets?: TicketAPIResult[]
 ) : void {
 
+  if (!GM_config.get('DISPLAY_SWARMING_CATEGORIES_ON_LIST')) {
+    return;
+  }
+
   if (tickets) {
     tableContainer.setAttribute('data-tickets', JSON.stringify(tickets));
   }

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        22.2
+// @version        22.3
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new
@@ -9,11 +9,16 @@
 // @include        /https:\/\/24475.apps.zdusercontent.com\/24475\/assets\/.*\/issue_creator.html/
 // @grant          unsafeWindow
 // @grant          GM.xmlHttpRequest
+// @grant          GM_getValue
+// @grant          GM_setValue
+// @grant          GM_registerMenuCommand
 // @require        https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js
 // @require        https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js
 // @require        https://unpkg.com/stackedit-js@1.0.7/docs/lib/stackedit.min.js
 // @require        https://unpkg.com/turndown@5.0.3/dist/turndown.js
+// @require        https://raw.githubusercontent.com/sizzlemctwizzle/GM_config/master/gm_config.js
 // ==/UserScript==
+
 
 /**
  * Compiled from TypeScript


### PR DESCRIPTION
Some people from the Spain support team are complaining about having the "Swarming Skills" list on every row of the tickets list because it makes every row bigger, so to see the same number of tickets, you have to scroll the ticket lists.

These people are manually modifying the script to remove this functionality.

In order to make it easier to add/remove this functionality, I have integrated a new **'GS_Config'** external library that allows you  creating a new script settings section from the "violentmonkey" plugin icon where you can configure the scripts:
![image](https://github.com/user-attachments/assets/3ae36f99-8a27-4567-8b6f-0d0ceec9917e)
This library was added on the first commit: https://github.com/holatuwol/liferay-zendesk-userscript/commit/a31847c632433cbf2d76acded2648891dc1d16b0 adding the option to configure the time execution interval of the script as an example.

You have more information about this library here: https://github.com/sizzlemctwizzle/GM_config

On the second commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/f05db302eed41915bed4a14bd7fa40bef76e062e, I have added a script setting that allows you to disable the swarming skills on ticket rows. By default, it will be always enabled, but the final users will be able to disable them.

On the third commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/01c193d3820ab750adc49ca2f148ef5a9f6714b2, I have created an additional script setting and logic that allows you to display/hide the account sub-organization of every ticket. This was implemented only for the Spanish office using a special ticket tag (spain_pod_a, spain_pod_c) that labels which team owns the ticket. (more information see [LRSUPPORT-44812](https://liferay.atlassian.net/browse/LRSUPPORT-44812) where the logic related to these tags where added )
As this was only implemented for the Spanish office, to prevent impacting other offices, it is disabled by default and you can manually enable it.

This is the final appearance of the settings window with all the configurations I have added:
![image](https://github.com/user-attachments/assets/14b232de-b025-4bdc-949c-5858b534050a)

The fourth commit https://github.com/holatuwol/liferay-zendesk-userscript/commit/37249b6577bbd2997cd70951ad742524f3bc7ea4 is unrelated to the GM_Config stuff. This is a minor fix of the product names (now called 'offerings') this code was originally added to make the column size narrower. With these changes, I am fixing the script to follow the new "Offering" column and the new values.

Let me know if you have any question.
