### PR TITLE
Display the account sub-organization in the ticket list for the US support office

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -519,7 +519,7 @@ GM_config.init({
           default: true
       },
       DISPLAY_SUB_ORGANIZATION_ON_LIST: {
-          label: '(Spain office only) Check this box if you want to display suborganization information below the ticket title in each row on filter views',
+          label: 'Check this box if you want to display suborganization information below the ticket title in each row on filter views',
           type: 'checkbox',
           default: false
       },

--- a/src/view_columns.ts
+++ b/src/view_columns.ts
@@ -88,7 +88,7 @@ function populateTicketTableExtraColumns(
 
         for (var j = 0; j < ticketTags.length; j++) {
         var tag = ticketTags[j];
-        if (tag.startsWith("spain_pod_")) {
+        if (tag.indexOf("_pod_") != -1) {
           var container;
           if (GM_config.get('DISPLAY_SWARMING_CATEGORIES_ON_LIST')) {
             container = document.createElement('div');

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        22.4
+// @version        22.5
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new


### PR DESCRIPTION
Ben Clement has asked to @jcampoy to extend the functionality added in e9e3138deca890aa3adfd30e7b49165ba04edbf8 that displays the Spain support office sub-organization information in the ticket list.

Now, current code checks the sub-organization tag with: `tag.startsWith("spain_pod_")` as our pods are `spain_pod_a`, `spain_pod_b`, `spain_pod_c`

The idea is to extend this code to also cover the teams of US office: `na_pod_manta_ray`, `na_pod_rayquaza`, `na_pod_x_ray`

New code just check that the tag contains `_pod_`:
```
if (tag.indexOf("_pod_") != -1) {
```