### PR TITLE
Add check for premium_service organization tag that is added to customers with trial TAM Services

### DIFF
--- a/src/priority.ts
+++ b/src/priority.ts
@@ -184,6 +184,7 @@ function addCustomerTypeMarker(
 ) : void {
 
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'tam_services', 'TAM Services', 'priority-critical');
+  addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'premium_service', 'Trial TAM Services', 'priority-critical');
 
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'gs_opportunity', 'GS Opportunity', 'priority-minor');
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'service_solution', 'Service Portal Customer', 'priority-minor');

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        23.1
+// @version        23.2
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new


### PR DESCRIPTION
Hi @holatuwol 

This change handles the `premium_service` organization tag in the same way that tam_services was done in https://github.com/holatuwol/liferay-zendesk-userscript/commit/6d94847c9e4e43dc328aa3d4124c6faac08684a8

This `premium_service` is applied to the customers with Trial TAM Services.

According to https://liferay.slack.com/archives/C04K22NHE0P/p1732029845651209?thread_ts=1731968364.203239&cid=C04K22NHE0P and https://liferay.atlassian.net/wiki/spaces/SUPPORT/pages/2227535957/2024+NA+Support+Comm+Meeting+Notes (11/13/24 archived notes):
 - `tam_services` - indicates they purchased TAM services
 - `premium_service` - indicates they are still in the trial

So I just added an additional line to handle the `premium_service` tag. 
