### PR TITLE
If the organization has both tam_services and premium_service don't display both, 'TAM Services' has priority over 'Trial TAM Services'

### DIFF
--- a/src/priority.ts
+++ b/src/priority.ts
@@ -184,7 +184,9 @@ function addCustomerTypeMarker(
 ) : void {
 
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'tam_services', 'TAM Services', 'priority-critical');
-  addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'premium_service', 'Trial TAM Services', 'priority-critical');
+  if (!organizationTagSet.has('tam_services')) {
+    addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'premium_service', 'Trial TAM Services', 'priority-critical');
+  }
 
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'gs_opportunity', 'GS Opportunity', 'priority-minor');
   addOrganizationTagSearchHeader(priorityElement, organizationTagSet, 'service_solution', 'Service Portal Customer', 'priority-minor');

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        23.2
+// @version        23.3
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new


### PR DESCRIPTION
Related to previous https://github.com/holatuwol/liferay-zendesk-userscript/pull/32 PR, it seems there are some tickets with both tags, so both 'TAM Services' and 'Trial TAM Services' are displayed.

To avoid this I am checking if `tam_services` tag is present before checking the `premium_service` one.

This can be reproduced with customer ticket 126603