### PR TITLE
Fix: SaaS marker not being added to SaaS projects 

### DIFF
--- a/src/priority.ts
+++ b/src/priority.ts
@@ -233,7 +233,7 @@ function addOfferingMarker(
 
   if (offeringText == 'SaaS') {
     for (var i = 0; i < ticketTags.length; i++) {
-      if (ticketTags[i].indexOf('lxc_sm') != -1) {
+      if (ticketTags[i] === 'lxc_sm') {
         offeringText = 'PaaS';
         offeringTag = ticketTags[i];
         break;

--- a/user_script.ts
+++ b/user_script.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        23.5
+// @version        23.6
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @supportURL     https://github.com/holatuwol/liferay-zendesk-userscript/issues/new


### PR DESCRIPTION
A tag that starts with `lxc_sm` is currently added for each Cloud component (see https://liferay.atlassian.net/wiki/spaces/~813112162/pages/2299199605/Help+Center+Tags and https://liferay.atlassian.net/wiki/spaces/SUPPORT/pages/2108065855/Liferay+Cloud+Components).

Because of that, no offering marker was being added in `addOrganizationTagSearchHeader`

To fix this, we should check if there is a tag called `lxc_sm` exactly. If so, use the 'PaaS' marker. Otherwise, use the 'SaaS' marker.

